### PR TITLE
Lock immutable.js to version 4.0.0-rc.4

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "polymer": "Polymer/polymer#^2.0.0",
     "iron-ajax": "PolymerElements/iron-ajax#^2.0.2",
-    "immutable": "facebook/immutable-js#^4.0.0"
+    "immutable": "facebook/immutable-js#v4.0.0-rc.4"
   },
   "devDependencies": {
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^2.0.0",


### PR DESCRIPTION
The `data-gql` element uses ImmutableJS library.

@leebyron decided to remove the `dist/` folder from the library (see: https://github.com/facebook/immutable-js/issues/1387). The `dist/` folder normally holds the `immutable.min.js` bundled file that is used by `data-gql`

```html
<script src="../../immutable/dist/immutable.min.js"></script>
```
Since the bundle can't be found and doesn't exists in ImmutableJS `v4.0.0-rc4+`, I suggest to stick to `rc-4` for the moment.