### PR TITLE
adds immutablejs element wrapper

### DIFF
--- a/data-gql/data-gql.html
+++ b/data-gql/data-gql.html
@@ -1,4 +1,4 @@
-<script src="../../immutable/dist/immutable.min.js"></script>
+<link rel="import" href="../data-imports/immutablejs-import.html">
 <link rel="import" href="../../polymer/polymer-element.html">
 <link rel="import" href="../../iron-ajax/iron-request.html">
 

--- a/data-imports/README.md
+++ b/data-imports/README.md
@@ -1,0 +1,4 @@
+# data-imports
+
+This folder contains element wrappers for javascript dependencies used by data-pipes.  
+These html import wrappers are used to help avoid duplicate script loading.

--- a/data-imports/immutablejs-import.html
+++ b/data-imports/immutablejs-import.html
@@ -1,0 +1,1 @@
+<script src="../../immutable/dist/immutable.min.js"></script>

--- a/data-rest/data-rest.html
+++ b/data-rest/data-rest.html
@@ -1,4 +1,4 @@
-<script src="../../immutable/dist/immutable.min.js"></script>
+<link rel="import" href="../data-imports/immutablejs-import.html">
 <link rel="import" href="../../polymer/polymer-element.html">
 <link rel="import" href="../../iron-ajax/iron-ajax.html">
 


### PR DESCRIPTION
modifies inclusion method of the immutable.js dependency so as to help avoid duplicate asset loading.
This proposal add a data-imports folder which could contain such wrapper elements.
Some further options to consider in handling external dependencies might be:
- extracting immutable-import.html to a separate repo to allow  inclusion in other project
- implementing automatic library detection 
- leaving the management of dependencies to the user (don't include reference to immutable, just expect its presence)